### PR TITLE
Updates for macOS m1

### DIFF
--- a/com.examples.hellodocker/pom.xml
+++ b/com.examples.hellodocker/pom.xml
@@ -31,7 +31,7 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>docker-maven-plugin</artifactId>
-            <version>0.34.1</version>
+            <version>0.38.1</version>
             <configuration>
               <showLogs>true</showLogs>
               <images>

--- a/com.examples.hellodocker/pom.xml
+++ b/com.examples.hellodocker/pom.xml
@@ -31,7 +31,7 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>docker-maven-plugin</artifactId>
-            <version>0.38.1</version>
+            <version>0.40.2</version>
             <configuration>
               <showLogs>true</showLogs>
               <images>


### PR DESCRIPTION
Updated the version of the docker maven plugin to make it work with Docker on macOS m1. 0.38.1 would be enough, but since we're updating, let's update to the latest version.